### PR TITLE
Azure Kinect

### DIFF
--- a/packs/dx11.particles/nodes/modules/DepthCameras/AzureKinect (DX11.Particles.Kinect) help.v4p
+++ b/packs/dx11.particles/nodes/modules/DepthCameras/AzureKinect (DX11.Particles.Kinect) help.v4p
@@ -1,0 +1,829 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha40.dtd" >
+   <PATCH nodename="C:\dev\vvvv\_KEEP\dx11-particles\packs\dx11.particles\nodes\modules\DepthCameras\AzureKinect (DX11.Particles.Kinect) help.v4p" scrollx="0" scrolly="30" systemname="AzureKinect (DX11.Particles.Kinect) help" filename="C:\dev\vvvv\_TEST\Azure\modules\AzureKinect (DX11.Particles.Kinect) help.v4p">
+   <BOUNDS type="Window" left="-180" top="495" width="14610" height="17655">
+   </BOUNDS>
+   <PACK Name="vvvv-ZeroMQ" Version="0.5.7">
+   </PACK>
+   <PACK Name="addonpack" Version="40.0.0">
+   </PACK>
+   <NODE systemname="Renderer (DX11)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11)" componentmode="InAWindow" id="7" stayontop="0">
+   <BOUNDS type="Node" left="3435" top="10290" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3435" top="10290" width="6000" height="4500">
+   </BOUNDS>
+   <BOUNDS type="Window" left="21105" top="315" width="7530" height="6045">
+   </BOUNDS>
+   <PIN pinname="Layers" visible="1">
+   </PIN>
+   <PIN pinname="View" visible="1">
+   </PIN>
+   <PIN pinname="Depth Buffer Mode" slicecount="1" values="Standard">
+   </PIN>
+   <PIN pinname="Depth Buffer Format" slicecount="1" values="D32_Float">
+   </PIN>
+   <PIN pinname="Background Color" slicecount="1" values="|0.55963,0.55963,0.55963,1.00000|">
+   </PIN>
+   </NODE>
+   <NODE systemname="AxisAndGrid (DX11)" filename="%VVVV%\packs\dx11\nodes\modules\AxisAndGrid\AxisAndGrid (DX11).v4p" nodename="AxisAndGrid (DX11)" componentmode="Hidden" id="8">
+   <BOUNDS type="Node" left="3240" top="8040" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="3240" top="8040">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="Group (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Group (DX11.Layer)" componentmode="Hidden" id="9">
+   <BOUNDS type="Node" left="4230" top="8595" width="2820" height="270">
+   </BOUNDS>
+   <PIN pinname="Layer 1" visible="1">
+   </PIN>
+   <PIN pinname="Layer Out" visible="1">
+   </PIN>
+   <PIN pinname="Input Count" slicecount="1" values="7">
+   </PIN>
+   <PIN pinname="Layer 2" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Layer 3" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Render State" visible="-1" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Enabled" visible="-1" pintype="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Layer 7" visible="1">
+   </PIN>
+   <PIN pinname="Layer 6" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="8" srcpinname="Layer" dstnodeid="9" dstpinname="Layer 1" linkstyle="VHV">
+   <LINKPOINT x="3300" y="8438">
+   </LINKPOINT>
+   <LINKPOINT x="4230" y="8438">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="AspectRatio (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="AspectRatio (DX11.Layer)" componentmode="Hidden" id="10">
+   <BOUNDS type="Node" left="3585" top="9885" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer In" visible="1">
+   </PIN>
+   <PIN pinname="Layer Out" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="3585" top="9885">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="9" srcpinname="Layer Out" dstnodeid="10" dstpinname="Layer In">
+   </LINK>
+   <LINK srcnodeid="10" srcpinname="Layer Out" dstnodeid="7" dstpinname="Layers">
+   </LINK>
+   <NODE systemname="Camera (Transform Softimage Legacy)" filename="%VVVV%\lib\nodes\modules\_legacy\Editing\Camera (Transform Softimage Legacy).v4p" nodename="Camera (Transform Softimage)" componentmode="Hidden" id="11">
+   <BOUNDS type="Node" left="4875" top="9885" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="View Projection" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="4875" top="9885">
+   </BOUNDS>
+   <PIN pinname="Initial Pitch" slicecount="1" values="0.06">
+   </PIN>
+   <PIN pinname="Initial Distance" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Initial Yaw" slicecount="1" values="-0.07">
+   </PIN>
+   <PIN pinname="Initial Interest" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="11" srcpinname="View Projection" dstnodeid="7" dstpinname="View">
+   </LINK>
+   <NODE systemname="ParticleSystem (DX11.Particles.Core)" filename="%VVVV%\packs\dx11.particles\nodes\modules\Core\ParticleSystem (DX11.Particles.Core).v4p" nodename="ParticleSystem (DX11.Particles.Core)" componentmode="Hidden" id="30">
+   <BOUNDS type="Node" left="5625" top="6930" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="ParticleSystemBuffers" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="5625" top="6930">
+   </BOUNDS>
+   <PIN pinname="Reset" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="ParticleCount" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Box (DX11.Geometry)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Box (DX11.Geometry)" componentmode="Hidden" id="32">
+   <BOUNDS type="Node" left="5145" top="7020" width="405" height="270">
+   </BOUNDS>
+   <PIN pinname="SizeXYZ" slicecount="3" values="0.01,0.01,0.01">
+   </PIN>
+   <PIN pinname="Geometry Out" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="5145" top="7020">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="33" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="4890" top="9030" width="795" height="720">
+   </BOUNDS>
+   <BOUNDS type="Node" left="4890" top="9030" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="3" visible="1" values="0.85,1,0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="33" srcpinname="Y Output Value" dstnodeid="11" dstpinname="Initial Interest">
+   </LINK>
+   <NODE systemname="Constant (DX11.Particles.Effect)" filename="%VVVV%\packs\dx11.particles\nodes\modules\Effects\Constant (DX11.Particles.Effect).v4p" nodename="Constant (DX11.Particles.Effect)" componentmode="Hidden" id="31">
+   <BOUNDS type="Node" left="5130" top="7440" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="ParticleSystemBuffers" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Geometry" visible="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Render State" visible="1">
+   </PIN>
+   <PIN pinname="Default Color" slicecount="1" values="|1.00000,1.00000,1.00000,0.35613|">
+   </PIN>
+   <PIN pinname="Technique" slicecount="1" values="Constant">
+   </PIN>
+   <BOUNDS type="Box" left="5130" top="7440">
+   </BOUNDS>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <PACK Name="vvvv-Message" Version="2.9.10">
+   </PACK>
+   <PACK Name="dx11" Version="1.3.1.1">
+   </PACK>
+   <PACK Name="dx11.particles" Version="1.0.5">
+   </PACK>
+   <PACK Name="VVVV.Packs.Image" Version="0.2.0">
+   </PACK>
+   <NODE systemname="Group (DX11.Layer)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Group (DX11.Layer)" componentmode="Hidden" id="48">
+   <BOUNDS type="Node" left="5640" top="5970" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5640" top="5970" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Layer 1" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Layer 2" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Layer Out" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="48" srcpinname="Layer Out" dstnodeid="30" dstpinname="Layer In">
+   </LINK>
+   <NODE systemname="RenderState (DX11)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="RenderState (DX11)" componentmode="Hidden" id="53">
+   <BOUNDS type="Node" left="3870" top="6990" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3870" top="6990" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Render State" visible="1">
+   </PIN>
+   <PIN pinname="Depth Stencil Mode" slicecount="1" values="NoDepth">
+   </PIN>
+   <PIN pinname="Blend Mode" slicecount="1" values="Disabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="53" srcpinname="Render State" dstnodeid="31" dstpinname="Render State">
+   </LINK>
+   <NODE nodename="Calibration (DX11.Particles.Kinect)" componentmode="Hidden" id="76" systemname="Calibration (DX11.Particles.Kinect)" filename="%VVVV%\packs\dx11.particles\nodes\modules\DepthCameras\Calibration (DX11.Particles.Kinect).v4p">
+   <BOUNDS type="Node" left="9750" top="9180" width="5145" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="9750" top="9180" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Help Layer" visible="1">
+   </PIN>
+   <PIN pinname="PointsXYZ From" visible="1">
+   </PIN>
+   <PIN pinname="Points XYZ To" visible="1" slicecount="12" values="-0.5,0,0,0.5,0,0,-0.5,0,1,0.5,0,1">
+   </PIN>
+   <PIN pinname="Error Threshold" visible="1">
+   </PIN>
+   <PIN pinname="Calibrate" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Success" visible="1">
+   </PIN>
+   <PIN pinname="Calibrating" visible="1">
+   </PIN>
+   <PIN pinname="Error" visible="1">
+   </PIN>
+   <PIN pinname="Transform Out" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="74" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="9750" top="4485" width="1935" height="1080">
+   </BOUNDS>
+   <BOUNDS type="Node" left="9750" top="4485" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Y Input Value">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Columns" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|PointsXYZ From|">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   </NODE>
+   <NODE systemname="PointSmooth (DX11.Particles.Tools Vector3d)" filename="%VVVV%\packs\dx11.particles\nodes\modules\Tools\PointSmooth (DX11.Particles.Tools Vector3d).v4p" nodename="PointSmooth (DX11.Particles.Tools Vector3d)" componentmode="Hidden" id="73">
+   <BOUNDS type="Node" left="9750" top="7515" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="InputXYZ" visible="1">
+   </PIN>
+   <PIN pinname="OutputXYZ" visible="1">
+   </PIN>
+   <PIN pinname="Update" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="9750" top="7515">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="73" dstpinname="InputXYZ">
+   </LINK>
+   <LINK srcnodeid="73" srcpinname="OutputXYZ" dstnodeid="76" dstpinname="PointsXYZ From">
+   </LINK>
+   <NODE systemname="EQ (Value)" nodename="EQ (Value)" componentmode="Hidden" id="71">
+   <BOUNDS type="Node" left="10500" top="6375" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="74" srcpinname="Y Output Value" dstnodeid="71" dstpinname="Input 1" linkstyle="VHV">
+   <LINKPOINT x="9810" y="5930">
+   </LINKPOINT>
+   <LINKPOINT x="10485" y="5980">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="AND (Boolean Spectral)" nodename="AND (Boolean Spectral)" componentmode="Hidden" id="70">
+   <BOUNDS type="Node" left="10500" top="6765" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Bin Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="71" srcpinname="Output" dstnodeid="70" dstpinname="Input">
+   </LINK>
+   <NODE systemname="NOT (Boolean)" nodename="NOT (Boolean)" componentmode="Hidden" id="69">
+   <BOUNDS type="Node" left="10500" top="7140" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="70" srcpinname="Output" dstnodeid="69" dstpinname="Input">
+   </LINK>
+   <LINK srcnodeid="69" srcpinname="Output" dstnodeid="73" dstpinname="Update">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="68" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="10365" top="3675" width="525" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="10365" top="3675" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="4">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Count">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="67" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="11565" top="2775" width="4830" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="11565" top="2775" width="5535" height="705">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Step1) Mark 4 meaningful points like a desk or a frame on the wall. Use the &quot;SetTexturePosition&quot; Renderer on the right. Left Mouse marks a point, right mouse switches between the control points.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="66" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="13875" top="4470" width="9270" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="13875" top="4470" width="5535" height="1590">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|Step2) Now setup these points in your virtual scene. Be sure that these points correspond to your real world points as good as possible! If your desk has a size of 1.0m x 2.0m the distance of the control points in the virtual scene has to be also 1.0 x 2.0. You can check that in the lower Renderer:&cr;&lf;Blue = marked points measured by kinect&cr;&lf;Green = the corresponding virtual points.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (String)" componentmode="InABox" id="65" systemname="IOBox (String)">
+   <BOUNDS type="Node" left="11085" top="7515" width="6930" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="11085" top="7515" width="2535" height="690">
+   </BOUNDS>
+   <PIN pinname="Input String" visible="0" slicecount="1" values="|&lt;&lt; This is just a little helper. It smoothes the measured points and ignores invalid coordinates.|">
+   </PIN>
+   <PIN pinname="Output String" visible="0">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="String Type" slicecount="1" values="MultiLine">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="64" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="13065" top="8715" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="13065" top="8715" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0.75">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Error Threshold|">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0.1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="64" srcpinname="Y Output Value" dstnodeid="76" dstpinname="Error Threshold">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="63" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="13560" top="9825" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="13560" top="9825" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Success">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="76" srcpinname="Success" dstnodeid="63" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="62" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="12300" top="9825" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="12300" top="9825" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Calibrating">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="76" srcpinname="Calibrating" dstnodeid="62" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="61" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="11010" top="9825" width="645" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="11010" top="9825" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Error">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="76" srcpinname="Error" dstnodeid="61" dstpinname="Y Input Value">
+   </LINK>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="60" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="9750" top="9825" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="9750" top="9825" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Transform Out|">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="76" srcpinname="Transform Out" dstnodeid="60" dstpinname="Input Node">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="90" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="14850" top="8415" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="14850" top="8415" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Bang">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Calibrate">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="90" srcpinname="Y Output Value" dstnodeid="76" dstpinname="Calibrate">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="92" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="14985" top="6375" width="1935" height="1080">
+   </BOUNDS>
+   <BOUNDS type="Node" left="14985" top="6375" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="12" visible="1" values="-0.5,0,0,0.5,0,0,-0.5,0,1,0.5,0,1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Columns" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Points XYZ To|">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="93" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="11790" top="4530" width="1935" height="1080">
+   </BOUNDS>
+   <BOUNDS type="Node" left="11790" top="4530" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="12" visible="1" values="-0.5,0,0,0.5,0,0,-0.5,0,-0.6,0.5,0,-0.6">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Columns" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Show Grid" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Points XYZ To|">
+   </PIN>
+   <PIN pinname="SliceCount Mode" slicecount="1" values="ColsRowsPages">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="93" srcpinname="Y Output Value" dstnodeid="76" dstpinname="Points XYZ To">
+   </LINK>
+   <NODE systemname="PerfMeter (DX11.Debug)" filename="%VVVV%\packs\dx11\nodes\modules\PerfMeter (DX11.Debug).v4p" nodename="PerfMeter (DX11.Debug)" componentmode="Hidden" id="94">
+   <BOUNDS type="Node" left="6990" top="8040" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="6990" top="8040">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="94" srcpinname="Layer" dstnodeid="9" dstpinname="Layer 7">
+   </LINK>
+   <NODE systemname="Preview (DX11.Texture)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Preview (DX11.Texture)" componentmode="InAWindow" id="127" stayontop="0" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="780" top="4140" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="780" top="4140" width="6000" height="4500">
+   </BOUNDS>
+   <BOUNDS type="Window" left="21075" top="5610" width="6240" height="6975">
+   </BOUNDS>
+   <PIN pinname="Show Alpha" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Depth">
+   </PIN>
+   </NODE>
+   <NODE systemname="Preview (DX11.Texture)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Preview (DX11.Texture)" componentmode="InAWindow" id="156" stayontop="0" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="780" top="4755" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="780" top="4755" width="6000" height="4500">
+   </BOUNDS>
+   <BOUNDS type="Window" left="20790" top="12465" width="6240" height="5085">
+   </BOUNDS>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Depth Rays|">
+   </PIN>
+   </NODE>
+   <NODE systemname="HSCB (DX11.TextureFX)" filename="%VVVV%\packs\dx11\nodes\texture11\Filter\HSCB.tfx" nodename="HSCB (DX11.TextureFX)" componentmode="Hidden" id="161" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="780" top="3750" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Texture In" visible="1">
+   </PIN>
+   <PIN pinname="Brightness" slicecount="1" values="5.09">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="780" top="3750">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="161" srcpinname="Texture Out" dstnodeid="127" dstpinname="Texture In">
+   </LINK>
+   <NODE systemname="Preview (DX11.Texture)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Preview (DX11.Texture)" componentmode="InAWindow" id="163" stayontop="0" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="780" top="3240" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="780" top="3240" width="6000" height="4500">
+   </BOUNDS>
+   <BOUNDS type="Window" left="13965" top="7245" width="6945" height="6450">
+   </BOUNDS>
+   <PIN pinname="Show Alpha" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="ColorToDepth">
+   </PIN>
+   </NODE>
+   <NODE systemname="Emitter (DX11.Particles.Emitter Kinect)" filename="%VVVV%\packs\dx11.particles\nodes\modules\Emitters\Emitter (DX11.Particles.Emitter Kinect).v4p" nodename="Emitter (DX11.Particles.Emitter Kinect)" componentmode="Hidden" id="164">
+   <BOUNDS type="Node" left="7335" top="4215" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="RGBDepth" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="World" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="RGB" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Raw RGBDepth" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Resolution" visible="1" slicecount="2" values="512,512">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="30" srcpinname="ParticleSystemBuffers" dstnodeid="31" dstpinname="ParticleSystemBuffers">
+   </LINK>
+   <NODE systemname="Preview (DX11.Texture)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Preview (DX11.Texture)" componentmode="InAWindow" id="173" stayontop="0" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="780" top="5340" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="780" top="5340" width="6000" height="4500">
+   </BOUNDS>
+   <BOUNDS type="Window" left="13560" top="9975" width="6945" height="6450">
+   </BOUNDS>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="World">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="164" srcpinname="Layer" dstnodeid="48" dstpinname="Layer 2" linkstyle="Bezier">
+   <LINKPOINT x="7320" y="5220">
+   </LINKPOINT>
+   <LINKPOINT x="6060" y="5220">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="PickPoints (DX11.Particles.Kinect)" filename="%VVVV%\packs\dx11.particles\nodes\modules\DepthCameras\PickPoints (DX11.Particles.Kinect).v4p" nodename="PickPoints (DX11.Particles.Kinect)" componentmode="Hidden" id="75">
+   <BOUNDS type="Node" left="9750" top="4065" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Resolution" visible="1">
+   </PIN>
+   <PIN pinname="RGB" visible="1">
+   </PIN>
+   <PIN pinname="Depth" visible="1">
+   </PIN>
+   <PIN pinname="RGBDepth" visible="1">
+   </PIN>
+   <PIN pinname="Depth FOVXY" visible="1">
+   </PIN>
+   <PIN pinname="PointsXYZ" visible="1">
+   </PIN>
+   <PIN pinname="Help Layer" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="9750" top="4065">
+   </BOUNDS>
+   <PIN pinname="Count" visible="1">
+   </PIN>
+   <PIN pinname="Texture RGBWorld" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture World" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture Depth" visible="1">
+   </PIN>
+   <BOUNDS type="Window" left="3660" top="2715" width="15630" height="14835">
+   </BOUNDS>
+   <PIN pinname="Initialize" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="75" srcpinname="PointsXYZ" dstnodeid="74" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="68" srcpinname="Y Output Value" dstnodeid="75" dstpinname="Count">
+   </LINK>
+   <LINK srcnodeid="31" srcpinname="Layer" dstnodeid="9" dstpinname="Layer 3">
+   </LINK>
+   <NODE systemname="IOBox (Node)" nodename="IOBox (Node)" componentmode="InABox" id="175">
+   <BOUNDS type="Node" left="6840" top="5445" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="6840" top="5445" width="795" height="240">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Calibration">
+   </PIN>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Output Node" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="175" srcpinname="Output Node" dstnodeid="31" dstpinname="Transform In" linkstyle="VHV">
+   <LINKPOINT x="6870" y="5835">
+   </LINKPOINT>
+   <LINKPOINT x="5475" y="5835">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="Box (DX11.Geometry)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Box (DX11.Geometry)" componentmode="Hidden" id="177">
+   <BOUNDS type="Node" left="4995" top="6315" width="405" height="270">
+   </BOUNDS>
+   <PIN pinname="SizeXYZ" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Geometry Out" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="4995" top="6315">
+   </BOUNDS>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="178" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="6975" top="6960" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6975" top="6960" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Integer">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="30" srcpinname="ParticleCount" dstnodeid="178" dstpinname="Y Input Value">
+   </LINK>
+   <LINK srcnodeid="32" srcpinname="Geometry Out" dstnodeid="31" dstpinname="Geometry">
+   </LINK>
+   <NODE systemname="AzureKinect (DX11.Particles.Kinect)" filename="AzureKinect (DX11.Particles.Kinect).v4p" nodename="AzureKinect (DX11.Particles.Kinect)" componentmode="InAWindow" id="188">
+   <BOUNDS type="Node" left="4695" top="2070" width="6120" height="270">
+   </BOUNDS>
+   <BOUNDS type="Window" left="13020" top="7065" width="10995" height="5700">
+   </BOUNDS>
+   <PIN pinname="Resolution" visible="1">
+   </PIN>
+   <PIN pinname="RGB" visible="1">
+   </PIN>
+   <PIN pinname="RGBDepth" visible="1">
+   </PIN>
+   <PIN pinname="World" visible="1">
+   </PIN>
+   <PIN pinname="RGBWorld" visible="1">
+   </PIN>
+   <PIN pinname="RayTable" visible="1" pintype="Output">
+   </PIN>
+   <PIN pinname="Depth FOVXY" visible="1" pintype="Output">
+   </PIN>
+   <PIN pinname="Depth" visible="1" pintype="Output">
+   </PIN>
+   <PIN pinname="Helper Layer" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   <PIN pinname="Enable Helper Layer" visible="1">
+   </PIN>
+   <PIN pinname="Is Started" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="188" srcpinname="Resolution" dstnodeid="164" dstpinname="Resolution" linkstyle="Bezier">
+   <LINKPOINT x="5430" y="3263">
+   </LINKPOINT>
+   <LINKPOINT x="7485" y="3263">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="RGB" dstnodeid="164" dstpinname="RGB" linkstyle="Bezier">
+   <LINKPOINT x="6105" y="3270">
+   </LINKPOINT>
+   <LINKPOINT x="7650" y="3270">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="RGBDepth" dstnodeid="164" dstpinname="RGBDepth" linkstyle="Bezier">
+   <LINKPOINT x="8070" y="3278">
+   </LINKPOINT>
+   <LINKPOINT x="7845" y="3278">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="World" dstnodeid="164" dstpinname="World" linkstyle="Bezier">
+   <LINKPOINT x="8730" y="3278">
+   </LINKPOINT>
+   <LINKPOINT x="8010" y="3278">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="World" dstnodeid="173" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="RGBWorld" dstnodeid="75" dstpinname="Texture RGBWorld" linkstyle="Bezier">
+   <LINKPOINT x="9450" y="3195">
+   </LINKPOINT>
+   <LINKPOINT x="10155" y="3195">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="RayTable" dstnodeid="156" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="RGB" dstnodeid="163" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="Depth" dstnodeid="161" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="World" dstnodeid="75" dstpinname="Texture World" linkstyle="Bezier">
+   <LINKPOINT x="8790" y="3195">
+   </LINKPOINT>
+   <LINKPOINT x="9945" y="3195">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="188" srcpinname="Helper Layer" dstnodeid="9" dstpinname="Layer 2">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="189" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="10755" top="1275" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="10755" top="1275" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="189" srcpinname="Y Output Value" dstnodeid="188" dstpinname="Enabled">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="190" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="8730" top="1695" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="8730" top="1695" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="0">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="0">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="190" srcpinname="Y Output Value" dstnodeid="188" dstpinname="Enable Helper Layer">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="191" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="10875" top="2100" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="10875" top="2100" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="188" srcpinname="Is Started" dstnodeid="191" dstpinname="Y Input Value">
+   </LINK>
+   </PATCH>

--- a/packs/dx11.particles/nodes/modules/DepthCameras/AzureKinect (DX11.Particles.Kinect).v4p
+++ b/packs/dx11.particles/nodes/modules/DepthCameras/AzureKinect (DX11.Particles.Kinect).v4p
@@ -1,0 +1,603 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha40.dtd" >
+   <PATCH nodename="C:\dev\vvvv\_KEEP\dx11-particles\packs\dx11.particles\nodes\modules\DepthCameras\AzureKinect (DX11.Particles.Kinect).v4p" systemname="AzureKinect (DX11.Particles.Kinect)" filename="C:\dev\vvvv\_TEST\Azure\modules\AzureKinect (DX11.Particles.Kinect).v4p" scrollx="1755" scrolly="195">
+   <NODE id="5" systemname="IOBox (Value Advanced)" componentmode="InABox" nodename="IOBox (Value Advanced)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="Resolution">
+   </PIN>
+   <BOUNDS type="Box" left="1635" top="4290" width="750" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1635" top="4290" width="750" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" visible="1" slicecount="2" values="256,256">
+   </PIN>
+   </NODE>
+   <NODE id="6" systemname="IOBox (Node)" componentmode="InABox" nodename="IOBox (Node)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="RGB">
+   </PIN>
+   <BOUNDS type="Box" left="2595" top="4290" width="630" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="2595" top="4290" width="750" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Node" slicecount="1" visible="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE id="7" systemname="IOBox (Value Advanced)" componentmode="InABox" nodename="IOBox (Value Advanced)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Depth FOVXY|">
+   </PIN>
+   <BOUNDS type="Box" left="9525" top="4290" width="750" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="9525" top="4290" width="750" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="2" values="0,0">
+   </PIN>
+   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
+   </PIN>
+   </NODE>
+   <NODE id="8" systemname="IOBox (Node)" componentmode="InABox" nodename="IOBox (Node)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="Depth">
+   </PIN>
+   <BOUNDS type="Box" left="3375" top="4290" width="600" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3375" top="4290" width="750" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Node" slicecount="1" visible="1" values="||">
+   </PIN>
+   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
+   </PIN>
+   </NODE>
+   <NODE id="9" systemname="IOBox (Node)" componentmode="InABox" nodename="IOBox (Node)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="RGBDepth">
+   </PIN>
+   <BOUNDS type="Box" left="5220" top="4290" width="750" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="5220" top="4290" width="750" height="240">
+   </BOUNDS>
+   <PIN pinname="Input Node" slicecount="1" visible="1" values="||">
+   </PIN>
+   </NODE>
+   <BOUNDS type="Window" left="13020" top="7065" width="10995" height="5700">
+   </BOUNDS>
+   <PACK Name="addonpack" Version="40.0.0">
+   </PACK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="11" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="10650" top="4290" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="10650" top="4290" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Is Started|">
+   </PIN>
+   <PIN pinname="Y Input Value" visible="1" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="13" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="7305" top="825" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="7305" top="825" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   </NODE>
+   <INFO author="velcrome" description="Wrapper for Kinect Azure" tags="k4a">
+   </INFO>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="14" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="255" top="4350" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="255" top="4350" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Kinect Runtime|">
+   </PIN>
+   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
+   </PIN>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="16" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="4245" top="4290" width="810" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="4245" top="4290" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="RayTable">
+   </PIN>
+   <PIN pinname="Pin Visibility" slicecount="1" values="OnlyInspector">
+   </PIN>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <PACK Name="vvvv-ZeroMQ" Version="0.5.7">
+   </PACK>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="28" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="6495" top="4290" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="6495" top="4290" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="World">
+   </PIN>
+   <PIN pinname="Input Node" visible="1" slicecount="1" values="||">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="30" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="7785" top="4290" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="7785" top="4290" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="RGBWorld">
+   </PIN>
+   </NODE>
+   <PACK Name="vvvv-Message" Version="2.9.10">
+   </PACK>
+   <NODE systemname="WorldRGB (DX11.TextureFX)" filename="%VVVV%\packs\dx11.particles\nodes\modules\DepthCameras\texture11\WorldRGB.tfx" nodename="WorldRGB (DX11.TextureFX)" componentmode="Hidden" id="29">
+   <BOUNDS type="Node" left="7785" top="3930" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Texture RGB" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture RGBDepth" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture World" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="7785" top="3930">
+   </BOUNDS>
+   <PIN pinname="Texture In" visible="1">
+   </PIN>
+   <PIN pinname="Default SizeXY" visible="1">
+   </PIN>
+   <PIN pinname="Use Default Size" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="29" srcpinname="Texture Out" dstnodeid="30" dstpinname="Input Node">
+   </LINK>
+   <PACK Name="dx11" Version="1.3.1.1">
+   </PACK>
+   <PACK Name="dx11.particles" Version="1.0.5">
+   </PACK>
+   <PACK Name="VVVV.Packs.Image" Version="0.2.0">
+   </PACK>
+   <NODE systemname="UploadImage (DX11.Texture)" filename="%VVVV%\lib\nugets\VL.VVVV.DirectX11.40.0.0-0023-gfb0b0cf57b\vvvv\nodes\plugins\VL.VVVV.DirectX11.dll" nodename="UploadImage (DX11.Texture)" componentmode="Hidden" id="37">
+   <BOUNDS type="Node" left="2595" top="3480" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="2595" top="3480" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Data" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <PIN pinname="Do Upload" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="37" srcpinname="Texture Out" dstnodeid="6" dstpinname="Input Node">
+   </LINK>
+   <NODE systemname="UploadImage (DX11.Texture)" filename="%VVVV%\lib\nugets\VL.VVVV.DirectX11.40.0.0-0023-gfb0b0cf57b\vvvv\nodes\plugins\VL.VVVV.DirectX11.dll" nodename="UploadImage (DX11.Texture)" componentmode="Hidden" id="38">
+   <BOUNDS type="Node" left="3360" top="2790" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3360" top="2790" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Data" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <PIN pinname="Do Upload" visible="1" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="38" srcpinname="Texture Out" dstnodeid="8" dstpinname="Input Node">
+   </LINK>
+   <NODE systemname="UploadBuffer (DX11.Buffer)" filename="%VVVV%\lib\nugets\VL.VVVV.DirectX11.40.0.0-0023-gfb0b0cf57b\vvvv\nodes\plugins\VL.VVVV.DirectX11.dll" nodename="UploadBuffer (DX11.Buffer)" componentmode="Hidden" id="39">
+   <BOUNDS type="Node" left="5715" top="2085" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="5715" top="2085" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Buffer Description" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Buffer" visible="1">
+   </PIN>
+   <PIN pinname="Keep In Memory" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Renderer (DX11 TempTarget)" filename="%VVVV%\packs\DX11\nodes\plugins\VVVV.DX11.Nodes.dll" nodename="Renderer (DX11 TempTarget)" componentmode="Hidden" id="40" hiddenwhenlocked="1">
+   <BOUNDS type="Node" left="6885" top="2085" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="-1" slicecount="1" pintype="Input" values="||">
+   </PIN>
+   <PIN pinname="Depth Buffer Mode" slicecount="1" values="None">
+   </PIN>
+   <PIN pinname="Depth Buffer Format" slicecount="1" values="D32_Float">
+   </PIN>
+   <PIN pinname="Texture Input Mode" slicecount="1" values="InheritSize">
+   </PIN>
+   <PIN pinname="Buffers" visible="1">
+   </PIN>
+   <PIN pinname="Texture SizeXY" visible="1" slicecount="2" values="256,256">
+   </PIN>
+   <PIN pinname="Texture In" visible="-1" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Generate Mip Maps" visible="-1" pintype="Input" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Shared Texture" visible="-1" pintype="Input" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Mip Map Levels" visible="-1" pintype="Input" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Clear" visible="-1" pintype="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Clear Depth" visible="-1" pintype="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Target Format" slicecount="1" visible="1" values="R16G16B16A16_Float">
+   </PIN>
+   <PIN pinname="Clear Depth Value" visible="-1" pintype="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Texture ScaleXY" visible="-1" pintype="Input" slicecount="2" values="1,1">
+   </PIN>
+   <PIN pinname="AA Samples per Pixel" visible="-1" pintype="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Background Color" visible="-1" pintype="Input" slicecount="1" values="|0.00000,0.00000,0.00000,1.00000|">
+   </PIN>
+   <PIN pinname="Enable Depth Buffer" visible="-1" pintype="Input" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="View" visible="-1" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Projection" visible="-1" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Aspect Ratio" visible="-1" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="ViewPort" visible="-1" pintype="Input" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Buffer SizeXY" visible="-1" pintype="Output">
+   </PIN>
+   <PIN pinname="Query" visible="-1" pintype="Output">
+   </PIN>
+   <BOUNDS type="Box" left="6885" top="2085">
+   </BOUNDS>
+   </NODE>
+   <NODE systemname="AzureKinect (Devices Microsoft)" filename="vl\VVVV.Devices.AzureKinect.vl" nodename="AzureKinect (Devices Microsoft)" componentmode="Hidden" id="44" hiddenwhenlocked="0">
+   <BOUNDS type="Node" left="255" top="1515" width="7080" height="270">
+   </BOUNDS>
+   <BOUNDS type="Box" left="255" top="1515">
+   </BOUNDS>
+   <PIN pinname="Depth Mode" visible="1">
+   </PIN>
+   <PIN pinname="FPS" visible="1">
+   </PIN>
+   <PIN pinname="Depth ResolutionXY" visible="1">
+   </PIN>
+   <PIN pinname="Point Buffer" visible="1">
+   </PIN>
+   <PIN pinname="Point Count" visible="1">
+   </PIN>
+   <PIN pinname="On Data" visible="1">
+   </PIN>
+   <PIN pinname="HasChanged" visible="1">
+   </PIN>
+   <PIN pinname="Has Started" visible="1">
+   </PIN>
+   <PIN pinname="IsStarted" visible="1">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="44" srcpinname="Depth FOVXY" dstnodeid="7" dstpinname="Y Input Value" linkstyle="Bezier" hiddenwhenlocked="1">
+   <LINKPOINT x="4980" y="3023">
+   </LINKPOINT>
+   <LINKPOINT x="9525" y="3023">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth ResolutionXY" dstnodeid="5" dstpinname="Y Input Value" linkstyle="Bezier">
+   <LINKPOINT x="4125" y="3030">
+   </LINKPOINT>
+   <LINKPOINT x="1695" y="3030">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="ColorDepth" dstnodeid="37" dstpinname="Data">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth" dstnodeid="38" dstpinname="Data">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="XYZ Table" dstnodeid="39" dstpinname="Buffer Description">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth ResolutionXY" dstnodeid="40" dstpinname="Texture SizeXY" linkstyle="Bezier">
+   <LINKPOINT x="4200" y="1920">
+   </LINKPOINT>
+   <LINKPOINT x="7215" y="1920">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Runtime" dstnodeid="14" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="37" srcpinname="Texture Out" dstnodeid="29" dstpinname="Texture RGB" linkstyle="VHV">
+   <LINKPOINT x="2655" y="3825">
+   </LINKPOINT>
+   <LINKPOINT x="8280" y="3825">
+   </LINKPOINT>
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="45">
+   <BOUNDS type="Box" left="240" top="885" width="1590" height="270">
+   </BOUNDS>
+   <BOUNDS type="Node" left="240" top="885" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" visible="1" values="WFOV_2x2Binned">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="Off">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Depth Mode|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="45" srcpinname="Output Enum" dstnodeid="44" dstpinname="Depth Mode">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="46">
+   <BOUNDS type="Box" left="3750" top="885" width="1590" height="270">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3750" top="885" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" visible="1" values="FPS15">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="FPS5">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="FPS">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="46" srcpinname="Output Enum" dstnodeid="44" dstpinname="FPS">
+   </LINK>
+   <NODE systemname="DebugAzure (DX11.Particles.Kinect)" filename="DebugAzure (DX11.Particles.Kinect).v4p" nodename="DebugAzure (DX11.Particles.Kinect)" componentmode="InAWindow" id="47">
+   <BOUNDS type="Node" left="840" top="2340" width="0" height="0">
+   </BOUNDS>
+   <BOUNDS type="Box" left="840" top="2340" width="6070" height="5205">
+   </BOUNDS>
+   <BOUNDS type="Window" left="3045" top="9525" width="6060" height="5205">
+   </BOUNDS>
+   <PIN pinname="Point Size" slicecount="3" values="0.01,0.01,0.01">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Point Buffer" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Point Count" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="44" srcpinname="Point Buffer" dstnodeid="47" dstpinname="Point Buffer">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Point Count" dstnodeid="47" dstpinname="Point Count">
+   </LINK>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="48">
+   <BOUNDS type="Box" left="840" top="3090" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="840" top="3090" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Helper Layer|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="47" srcpinname="Layer" dstnodeid="48" dstpinname="Input Node">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="50">
+   <BOUNDS type="Box" left="5775" top="885" width="285" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="5775" top="885" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Enable Helper Layer|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="50" srcpinname="Y Output Value" dstnodeid="47" dstpinname="Enabled" hiddenwhenlocked="1">
+   </LINK>
+   <NODE nodename="IOBox (Enumerations)" componentmode="InABox" id="51">
+   <BOUNDS type="Box" left="7620" top="2055" width="1860" height="285">
+   </BOUNDS>
+   <BOUNDS type="Node" left="7620" top="2055" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Enum" slicecount="1" visible="1" values="R16G16B16A16_Float">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="R32G32B32A32_Float">
+   </PIN>
+   <PIN pinname="File Mask" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Maximum Characters" slicecount="1" values="-1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="51" srcpinname="Output Enum" dstnodeid="40" dstpinname="Target Format">
+   </LINK>
+   <LINK srcnodeid="40" srcpinname="Buffers" dstnodeid="29" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth ResolutionXY" dstnodeid="29" dstpinname="Default SizeXY" linkstyle="Bezier">
+   <LINKPOINT x="4200" y="2843">
+   </LINKPOINT>
+   <LINKPOINT x="8115" y="2843">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="AzureTextures (DX11.TextureFX)" filename="texture11\AzureTextures.tfx" nodename="AzureTextures (DX11.TextureFX)" componentmode="Hidden" id="42">
+   <BOUNDS type="Node" left="5220" top="3480" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Texture Depth" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture RGB Aligned" visible="1">
+   </PIN>
+   <PIN pinname="Default SizeXY" visible="1" slicecount="2" values="256,256">
+   </PIN>
+   <PIN pinname="Use Default Size" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Technique" slicecount="1" values="RGBDepth">
+   </PIN>
+   <PIN pinname="Texture Depth Raytable" visible="1" slicecount="1" values="||">
+   </PIN>
+   <BOUNDS type="Box" left="5220" top="3480">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="40" srcpinname="Buffers" dstnodeid="42" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="42" srcpinname="Texture Out" dstnodeid="9" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="42" srcpinname="Texture Out" dstnodeid="29" dstpinname="Texture RGBDepth" linkstyle="VHV">
+   <LINKPOINT x="5280" y="3825">
+   </LINKPOINT>
+   <LINKPOINT x="8430" y="3825">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth ResolutionXY" dstnodeid="42" dstpinname="Default SizeXY" linkstyle="Bezier">
+   <LINKPOINT x="4170" y="3840">
+   </LINKPOINT>
+   <LINKPOINT x="5445" y="3030">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="AzureTextures (DX11.TextureFX)" filename="texture11\AzureTextures.tfx" nodename="AzureTextures (DX11.TextureFX)" componentmode="Hidden" id="41">
+   <BOUNDS type="Node" left="6495" top="3480" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Texture Depth" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Texture RGB Aligned" visible="1">
+   </PIN>
+   <PIN pinname="Default SizeXY" visible="1" slicecount="2" values="256,256">
+   </PIN>
+   <PIN pinname="Use Default Size" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <PIN pinname="Texture In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Enabled" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Technique" slicecount="1" values="World">
+   </PIN>
+   <PIN pinname="Texture Depth Raytable" visible="1" slicecount="1" values="||">
+   </PIN>
+   <BOUNDS type="Box" left="6495" top="3480">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="38" srcpinname="Texture Out" dstnodeid="41" dstpinname="Texture Depth" linkstyle="VHV">
+   <LINKPOINT x="3465" y="3255">
+   </LINKPOINT>
+   <LINKPOINT x="6945" y="3255">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="41" srcpinname="Texture Out" dstnodeid="28" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="40" srcpinname="Buffers" dstnodeid="41" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth ResolutionXY" dstnodeid="41" dstpinname="Default SizeXY" linkstyle="Bezier">
+   <LINKPOINT x="4255" y="2625">
+   </LINKPOINT>
+   <LINKPOINT x="6800" y="2115">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="41" srcpinname="Texture Out" dstnodeid="29" dstpinname="Texture World" linkstyle="VHV">
+   <LINKPOINT x="6500" y="3825">
+   </LINKPOINT>
+   <LINKPOINT x="8650" y="3825">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="AzureTextures (DX11.TextureFX)" filename="texture11\AzureTextures.tfx" nodename="AzureTextures (DX11.TextureFX)" componentmode="Hidden" id="36">
+   <BOUNDS type="Node" left="4860" top="2790" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Ray Buffer" visible="1">
+   </PIN>
+   <PIN pinname="Texture In" visible="1">
+   </PIN>
+   <PIN pinname="Texture Out" visible="1">
+   </PIN>
+   <BOUNDS type="Box" left="4860" top="2790">
+   </BOUNDS>
+   <PIN pinname="Default SizeXY" visible="1">
+   </PIN>
+   <PIN pinname="Use Default Size" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="39" srcpinname="Buffer" dstnodeid="36" dstpinname="Ray Buffer">
+   </LINK>
+   <LINK srcnodeid="40" srcpinname="Buffers" dstnodeid="36" dstpinname="Texture In" hiddenwhenlocked="1">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Texture Out" dstnodeid="16" dstpinname="Input Node" linkstyle="PolyLine">
+   </LINK>
+   <LINK srcnodeid="36" srcpinname="Texture Out" dstnodeid="41" dstpinname="Texture Depth Raytable" linkstyle="VHV">
+   <LINKPOINT x="5095" y="3255">
+   </LINKPOINT>
+   <LINKPOINT x="6980" y="3255">
+   </LINKPOINT>
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="Depth ResolutionXY" dstnodeid="36" dstpinname="Default SizeXY">
+   </LINK>
+   <LINK srcnodeid="44" srcpinname="IsStarted" dstnodeid="11" dstpinname="Y Input Value" linkstyle="VHV">
+   <LINKPOINT x="7305" y="1890">
+   </LINKPOINT>
+   <LINKPOINT x="10680" y="1890">
+   </LINKPOINT>
+   </LINK>
+   <NODE systemname="OnOpen (VVVV)" nodename="OnOpen (VVVV)" componentmode="Hidden" id="52">
+   <BOUNDS type="Node" left="8190" top="375" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Bang" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="MonoFlop (Animation Framebased)" filename="%VVVV%\addonpack\lib\nodes\plugins\MonoFlop.dll" nodename="MonoFlop (Animation Framebased)" componentmode="Hidden" id="54">
+   <BOUNDS type="Node" left="8190" top="705" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="8190" top="705" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Set" visible="1">
+   </PIN>
+   <PIN pinname="Frames" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Inverse Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="52" srcpinname="Bang" dstnodeid="54" dstpinname="Set">
+   </LINK>
+   <NODE systemname="AND (Boolean)" nodename="AND (Boolean)" componentmode="Hidden" id="55">
+   <BOUNDS type="Node" left="7305" top="1125" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="Input 2" visible="1">
+   </PIN>
+   <PIN pinname="Input 1" visible="1">
+   </PIN>
+   <PIN pinname="Output" visible="1">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="54" srcpinname="Inverse Output" dstnodeid="55" dstpinname="Input 2">
+   </LINK>
+   <LINK srcnodeid="13" srcpinname="Y Output Value" dstnodeid="55" dstpinname="Input 1">
+   </LINK>
+   <LINK srcnodeid="55" srcpinname="Output" dstnodeid="44" dstpinname="Enabled">
+   </LINK>
+   <LINK srcnodeid="55" srcpinname="Output" dstnodeid="38" dstpinname="Do Upload">
+   </LINK>
+   <LINK srcnodeid="55" srcpinname="Output" dstnodeid="37" dstpinname="Do Upload">
+   </LINK>
+   </PATCH>

--- a/packs/dx11.particles/nodes/modules/DepthCameras/DebugAzure (DX11.Particles.Kinect).v4p
+++ b/packs/dx11.particles/nodes/modules/DepthCameras/DebugAzure (DX11.Particles.Kinect).v4p
@@ -1,0 +1,253 @@
+<!DOCTYPE PATCH  SYSTEM "http://vvvv.org/versions/vvvv50alpha40.dtd" >
+   <PATCH nodename="C:\dev\vvvv\_TEST\Azure\modules\DebugAzure (DX11.Particles.Kinect).v4p" systemname="DebugAzure (DX11.Particles.Kinect)" filename="C:\dev\vvvv\_TEST\Azure\modules\DebugAzure (DX11.Particles.Kinect).v4p">
+   <NODE systemname="UploadBuffer (DX11.Buffer)" filename="%VVVV%\lib\nugets\VL.VVVV.DirectX11.40.0.0-0023-gfb0b0cf57b\vvvv\nodes\plugins\VL.VVVV.DirectX11.dll" nodename="UploadBuffer (DX11.Buffer)" componentmode="Hidden" id="0">
+   <BOUNDS type="Node" left="3135" top="1500" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="3135" top="1500" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Buffer Description" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Is Valid" visible="1">
+   </PIN>
+   <PIN pinname="Buffer" visible="1">
+   </PIN>
+   <PIN pinname="Keep In Memory" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="TranslateVector (Transform Buffer)" filename="%VVVV%\packs\InstanceNoodles\nodes\modules\Compute\Transform Buffer\TranslateVector (Transform Buffer)\TranslateVector (Transform Buffer).v4p" nodename="TranslateVector (Transform Buffer)" componentmode="Hidden" id="1">
+   <BOUNDS type="Node" left="2490" top="2925" width="100" height="100">
+   </BOUNDS>
+   <PIN pinname="PosXYZ" visible="1" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Transform Buffer" visible="1">
+   </PIN>
+   <PIN pinname="Spread Count" visible="1">
+   </PIN>
+   <PIN pinname="Pos 3D Buffer" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Box (DX11.Geometry)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Box (DX11.Geometry)" componentmode="Hidden" id="2">
+   <BOUNDS type="Node" left="1260" top="2520" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1260" top="2520" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Geometry Out" visible="1">
+   </PIN>
+   <PIN pinname="SizeXYZ" slicecount="1" visible="1" values="-0.01">
+   </PIN>
+   </NODE>
+   <NODE systemname="DynamicBuffer (DX11.Buffer Color)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="DynamicBuffer (DX11.Buffer Color)" componentmode="Hidden" id="3">
+   <BOUNDS type="Node" left="4410" top="1065" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="4410" top="1065" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Buffer" visible="1">
+   </PIN>
+   <PIN pinname="Data" visible="1">
+   </PIN>
+   </NODE>
+   <NODE systemname="Instancer (DX11.Drawer)" filename="%VVVV%\packs\dx11\nodes\plugins\base\VVVV.DX11.Nodes.dll" nodename="Instancer (DX11.Drawer)" componentmode="Hidden" id="5">
+   <BOUNDS type="Node" left="1515" top="3015" width="100" height="100">
+   </BOUNDS>
+   <BOUNDS type="Box" left="1515" top="3015" width="3000" height="3000">
+   </BOUNDS>
+   <PIN pinname="Geometry In" visible="1">
+   </PIN>
+   <PIN pinname="Geometry Out" visible="1">
+   </PIN>
+   <PIN pinname="Instance Count" visible="1">
+   </PIN>
+   </NODE>
+   <NODE componentmode="Hidden" filename="%VVVV%\packs\dx11\nodes\dx11\ConstantInstanced.fx" id="6" nodename="ConstantInstanced (DX11.Effect)" systemname="ConstantInstanced (DX11.Effect)">
+   <BOUNDS height="270" left="2205" top="3435" type="Node" width="1665">
+   </BOUNDS>
+   <PIN pinname="Layer" visible="1">
+   </PIN>
+   <PIN pinname="Geometry" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Transform In" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Technique" slicecount="1" values="Constant">
+   </PIN>
+   <PIN pinname="texture2d" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Render State" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Render Time" visible="1">
+   </PIN>
+   <PIN pinname="g_samLinear" visible="1">
+   </PIN>
+   <PIN pinname="cAmb">
+   </PIN>
+   <PIN pinname="ref">
+   </PIN>
+   <PIN pinname="rough">
+   </PIN>
+   <PIN pinname="Ambient Color">
+   </PIN>
+   <PIN pinname="Light DirectionXYZ" visible="1">
+   </PIN>
+   <PIN pinname="bb">
+   </PIN>
+   <PIN pinname="Specular Color">
+   </PIN>
+   <PIN pinname="Diffuse Color">
+   </PIN>
+   <PIN pinname="Power">
+   </PIN>
+   <PIN pinname="fAnisotropicRoughnessXY" visible="1">
+   </PIN>
+   <PIN pinname="Light PositionXYZ" visible="1">
+   </PIN>
+   <PIN pinname="Light Attenuation 0">
+   </PIN>
+   <PIN pinname="Light Attenuation 1">
+   </PIN>
+   <PIN pinname="Light Range">
+   </PIN>
+   <PIN pinname="Light Attenuation 2">
+   </PIN>
+   <PIN pinname="sbColor" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="colorcount" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="sbWorld" visible="1" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Enabled" visible="1">
+   </PIN>
+   </NODE>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="7" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="5205" top="2145" width="480" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="5205" top="2145" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="1" visible="1" values="1">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Value Type" slicecount="1" values="Boolean">
+   </PIN>
+   <PIN pinname="Behavior" slicecount="1" values="Toggle">
+   </PIN>
+   <PIN pinname="X Input Value" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Enabled">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="2" srcpinname="Geometry Out" dstnodeid="5" dstpinname="Geometry In">
+   </LINK>
+   <LINK srcnodeid="5" srcpinname="Geometry Out" dstnodeid="6" dstpinname="Geometry">
+   </LINK>
+   <LINK srcnodeid="1" srcpinname="Transform Buffer" dstnodeid="6" dstpinname="sbWorld">
+   </LINK>
+   <LINK srcnodeid="3" srcpinname="Buffer" dstnodeid="6" dstpinname="sbColor">
+   </LINK>
+   <LINK srcnodeid="7" srcpinname="Y Output Value" dstnodeid="6" dstpinname="Enabled">
+   </LINK>
+   <NODE id="8" systemname="IOBox (Node)" componentmode="InABox" nodename="IOBox (Node)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="Layer">
+   </PIN>
+   <BOUNDS type="Box" left="2205" top="4205" width="750" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="2205" top="4205" width="750" height="240">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="6" srcpinname="Layer" dstnodeid="8" dstpinname="Input Node">
+   </LINK>
+   <LINK srcnodeid="0" srcpinname="Buffer" dstnodeid="1" dstpinname="Pos 3D Buffer">
+   </LINK>
+   <NODE id="9" systemname="IOBox (Node)" componentmode="InABox" nodename="IOBox (Node)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Point Buffer|">
+   </PIN>
+   <BOUNDS type="Box" left="645" top="345" width="750" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="645" top="345" width="750" height="240">
+   </BOUNDS>
+   </NODE>
+   <LINK srcnodeid="9" srcpinname="Output Node" dstnodeid="0" dstpinname="Buffer Description">
+   </LINK>
+   <NODE id="10" systemname="IOBox (Value Advanced)" componentmode="InABox" nodename="IOBox (Value Advanced)">
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Point Count|">
+   </PIN>
+   <BOUNDS type="Box" left="1860" top="345" width="750" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="1860" top="345" width="750" height="240">
+   </BOUNDS>
+   <PIN pinname="Y Output Value" visible="1">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="6000">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="1">
+   </PIN>
+   </NODE>
+   <BOUNDS type="Window" left="3045" top="9525" width="6060" height="5205">
+   </BOUNDS>
+   <PACK Name="dx11" Version="1.3.1.1">
+   </PACK>
+   <PACK Name="dx11.particles" Version="1.0.5">
+   </PACK>
+   <PACK Name="vvvv-Message" Version="2.9.10">
+   </PACK>
+   <PACK Name="vvvv-ZeroMQ" Version="0.5.7">
+   </PACK>
+   <PACK Name="VVVV.Packs.Image" Version="0.2.0">
+   </PACK>
+   <PACK Name="addonpack" Version="40.0.0">
+   </PACK>
+   <NODE nodename="IOBox (Color)" componentmode="InABox" id="11" systemname="IOBox (Color)">
+   <BOUNDS type="Box" left="4440" top="345" width="2250" height="480">
+   </BOUNDS>
+   <BOUNDS type="Node" left="4440" top="345" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Color Input" slicecount="1" visible="1" values="|0.00000,1.00000,0.00000,1.00000|">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="Color">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="11" srcpinname="Color Output" dstnodeid="3" dstpinname="Data">
+   </LINK>
+   <NODE nodename="IOBox (Value Advanced)" componentmode="InABox" id="12" systemname="IOBox (Value Advanced)">
+   <BOUNDS type="Box" left="3225" top="345" width="795" height="720">
+   </BOUNDS>
+   <BOUNDS type="Node" left="3225" top="345" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Y Input Value" slicecount="3" visible="1" values="0.01,0.01,0.01">
+   </PIN>
+   <PIN pinname="Units" slicecount="1" values="||">
+   </PIN>
+   <PIN pinname="Precision" slicecount="1" values="4">
+   </PIN>
+   <PIN pinname="Vector Size" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Rows" slicecount="1" values="3">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Point Size|">
+   </PIN>
+   <PIN pinname="Minimum" slicecount="1" values="0">
+   </PIN>
+   <PIN pinname="Maximum" slicecount="1" values="1">
+   </PIN>
+   <PIN pinname="Default" slicecount="1" values="0.01">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="12" srcpinname="Y Output Value" dstnodeid="2" dstpinname="SizeXYZ">
+   </LINK>
+   <LINK srcnodeid="10" srcpinname="Y Output Value" dstnodeid="1" dstpinname="Spread Count">
+   </LINK>
+   <LINK srcnodeid="10" srcpinname="Y Output Value" dstnodeid="5" dstpinname="Instance Count">
+   </LINK>
+   <NODE nodename="IOBox (Node)" componentmode="InABox" id="13" systemname="IOBox (Node)">
+   <BOUNDS type="Box" left="405" top="1335" width="795" height="240">
+   </BOUNDS>
+   <BOUNDS type="Node" left="405" top="1335" width="0" height="0">
+   </BOUNDS>
+   <PIN pinname="Input Node" slicecount="1" visible="1" values="||">
+   </PIN>
+   <PIN pinname="Descriptive Name" slicecount="1" values="|Transform In|">
+   </PIN>
+   </NODE>
+   <LINK srcnodeid="13" srcpinname="Output Node" dstnodeid="6" dstpinname="Transform In">
+   </LINK>
+   </PATCH>

--- a/packs/dx11.particles/nodes/modules/DepthCameras/texture11/AzureTextures.tfx
+++ b/packs/dx11.particles/nodes/modules/DepthCameras/texture11/AzureTextures.tfx
@@ -1,0 +1,50 @@
+Texture2D texDepth <string uiname="Texture Depth";>;
+Texture2D texRaytable <string uiname="Texture Depth Raytable";>;
+StructuredBuffer<float2> Ray <string uiname="Ray Buffer";>;
+
+SamplerState sPoint : IMMUTABLE
+{
+    Filter = MIN_MAG_MIP_POINT;
+    AddressU = Border;
+    AddressV = Border;
+};
+
+cbuffer controls:register(b0)
+{
+	float2 R: TARGETSIZE;
+
+};
+
+float4 GenerateWorld(float4 PosWVP:SV_POSITION,float2 uv:TEXCOORD0):SV_TARGET{
+	float2 coord = uv; // pixelwise alignment of world texture to depth texture
+	
+	float depth =  texDepth.SampleLevel(sPoint, coord,0 ).r * 65.535 ;
+	float2 ray =  texRaytable.SampleLevel(sPoint, coord,0 ).xy ;
+	
+	float4 position = 0;
+
+	position.x = ray.x * depth; // https://docs.microsoft.com/en-us/azure/kinect-dk/use-image-transformation
+    position.y = ray.y * depth;		
+    position.z = depth;
+	
+	return position;
+}
+
+float4 GenerateUV(float4 PosWVP:SV_POSITION,float2 uv:TEXCOORD0):SV_TARGET{
+	float4 position = 0;	// azure kinect sdk already aligns rgb to depth
+	position.xy = uv; 		// so RGBWorld lookup table is trivial and only for compatibility with existing Emitters
+	return position;
+	
+}
+
+
+float4 GenerateRaytable (float4 PosWVP:SV_POSITION,float2 uv:TEXCOORD0):SV_Target{
+	uint uvi = (uv.x+0.5) * R.x + (1-uv.y) * R.x*R.y;
+	float2 coord = Ray[uvi];	
+
+	return float4(coord.x, coord.y,0,0.5);
+}
+
+technique11 Raytable{pass P0{SetPixelShader(CompileShader(ps_4_0,GenerateRaytable()));}}
+technique10 World{pass P1{SetPixelShader(CompileShader(ps_4_0,GenerateWorld()));}}
+technique10 RGBDepth{pass P1{SetPixelShader(CompileShader(ps_4_0,GenerateUV()));}}

--- a/packs/dx11.particles/nodes/modules/DepthCameras/vl/VVVV.Devices.AzureKinect.vl
+++ b/packs/dx11.particles/nodes/modules/DepthCameras/vl/VVVV.Devices.AzureKinect.vl
@@ -1,0 +1,292 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Document xmlns:p="property" Id="UiJVAZV3NtxPWeXGRURIMU" LanguageVersion="2020.1.4.167" Version="0.128">
+  <NugetDependency Id="RKFCmk1Lg5EP3I4IQegLTw" Location="VL.CoreLib" Version="2020.1.4" />
+  <NugetDependency Id="U2JwHqMJLyGLDs97lM6eZ6" Location="VL.CoreLib.VVVV" Version="40.0.0-0023-gfb0b0cf57b" />
+  <Patch Id="Th8hpfHvBF4Lk6VOwDCc9D">
+    <Canvas Id="NtZT52Xp5qNOXK0fF2H7kv" DefaultCategory="VVVV.Devices" CanvasType="FullCategory">
+      <!--
+
+    ************************ AzureKinect (Microsoft) ************************
+
+-->
+      <Node Name="AzureKinect (Microsoft)" Bounds="153,200" Id="TSttkfeJHQSN5gkEF54G9o">
+        <p:NodeReference>
+          <Choice Kind="ContainerDefinition" Name="Patch" />
+          <FullNameCategoryReference ID="Primitive" />
+        </p:NodeReference>
+        <Patch Id="CzjSvRY5dvXQDxmAOA8mZj">
+          <Patch Id="ESJZDDS0I02LAWDOx9RJVV" Name="Create" />
+          <Patch Id="OkqGvJfa3PDOppp4PFQghD" Name="Update">
+            <Pin Id="Dibzz50jh3qL2fhuIZ8rFg" Name="Depth" Kind="OutputPin" Bounds="259,380" />
+            <Pin Id="KhFw1lUlEe8OJdgweOfAeX" Name="Enabled" Kind="InputPin" Bounds="675,136" />
+            <Pin Id="TTSxvzhmYZaPgsbKXSnTnx" Name="Depth FOV" Kind="OutputPin" Bounds="602,344" />
+            <Pin Id="IuHLsV00fJkLQcLes8NVvC" Name="Depth Resolution" Kind="OutputPin" Bounds="519,591" />
+            <Pin Id="JGiEnFgnn43PIbgtVxm8fl" Name="ColorDepth" Kind="OutputPin" Bounds="125,412" />
+            <Pin Id="QEIPQSuDEyVL1cXY9KLFR3" Name="Point Buffer" Kind="OutputPin" Bounds="232,508" />
+            <Pin Id="R0ezdmFbyhEPx3CmmTohGM" Name="XYZ Table" Kind="OutputPin" Bounds="581,696" />
+            <Pin Id="RfhLHlTKCf3PHEANMG69bO" Name="HasChanged" Kind="OutputPin" Bounds="655,635" />
+            <Pin Id="GxnPj7AARp3MQ6y8bspCcv" Name="Depth Mode" Kind="InputPin" Bounds="418,-6" DefaultValue="WFOV_2x2Binned">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <Choice Kind="TypeFlag" Name="DepthMode" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="TSx9JfyLSN2O4oZdd0at20" Name="FPS" Kind="InputPin" Bounds="608,132" DefaultValue="FPS15">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <Choice Kind="TypeFlag" Name="FPS" />
+              </p:TypeAnnotation>
+            </Pin>
+            <Pin Id="V06Ud1YtPNoMU3ukQaCXg3" Name="Point Count" Kind="OutputPin" Bounds="304,421" />
+            <Pin Id="UgE9bgHaeguL8v8xBbS2Mp" Name="Runtime" Kind="OutputPin" Bounds="134,269" />
+            <Pin Id="R4GHi5w35d6PbqVFQtEXIE" Name="IsStarted" Kind="OutputPin" Bounds="1030,527" />
+          </Patch>
+          <Canvas Id="C4yd3S6BFv9NWqJ2WO3OFi" CanvasType="Group">
+            <Node Bounds="385,230,105,19" Id="MxTx2pGkx3YM9hCCRBykLR">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="AzureKinect" />
+              </p:NodeReference>
+              <Pin Id="Hmcw1tsEhStOUXADVDYejo" Name="Device Index" Kind="InputPin" />
+              <Pin Id="AGR24cHmhEKQFGAhKdZuqB" Name="Color Resolution" Kind="InputPin" />
+              <Pin Id="GijOIAKPAEsP13nlZ2ww3N" Name="Depth Mode" Kind="InputPin" />
+              <Pin Id="Vt7YUxbAc2yLJEmfnLjWJF" Name="FPS" Kind="InputPin" />
+              <Pin Id="UJBHYRrRq2GN7qhZX4Wf6F" Name="Wired Sync Mode" Kind="InputPin" />
+              <Pin Id="DGUtQKzu7BZLhXaMnimNuE" Name="Enabled" Kind="InputPin" />
+              <Pin Id="NEB5RMChfrNMmwByqXXDPg" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="572,318,77,19" Id="QvOOyIixQQXPyI4apDJqNM">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="DepthImage" />
+              </p:NodeReference>
+              <Pin Id="I7lOSjrOXOiNKLrh3hvx8O" Name="Device" Kind="InputPin" />
+              <Pin Id="K2Unpt8IrMbQC1qkgCzNeT" Name="Output" Kind="OutputPin" />
+              <Pin Id="OEqm2crhlERPTn9x3o3b65" Name="On Data" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="KrVnZKn4szVPR6qBjIaOuU" Bounds="579,441" />
+            <ControlPoint Id="Itr4TMRwsLkLt6mseVE94K" Bounds="504,180" />
+            <Pad Id="OcacivhCKGFOQdmSLqlhbh" Comment="Depth Mode" Bounds="626,68,108,15" ShowValueBox="true" isIOBox="true" Value="NFOV_2x2Binned">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <Choice Kind="TypeFlag" Name="DepthMode" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="767,297,85,19" Id="TnkKNhmR8BkO8jZ4isl6Fj">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="AzureKinect" />
+                <Choice Kind="ProcessAppFlag" Name="FOV" />
+              </p:NodeReference>
+              <Pin Id="LKLFSuOSdVoNbJIzHOHoXH" Name="Device" Kind="InputPin" />
+              <Pin Id="TOgkPI2k1OPObFqaaP3apR" Name="Color View Transform" Kind="OutputPin" />
+              <Pin Id="CkjSowrxGU0P2jZLBawUPh" Name="Color FOV" Kind="OutputPin" />
+              <Pin Id="NzvuupWs3U2Ox7wqlgm0ij" Name="Color Resolution" Kind="OutputPin" />
+              <Pin Id="P5PQM3632ajPn3vbVCMBnu" Name="Depth FOV" Kind="OutputPin" />
+              <Pin Id="Cg8BEhb9WwkNMVH0G27nRu" Name="Depth Mode" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="VqbBx7CkZvbLfykQONyeP1" Bounds="830,351" />
+            <Pad Id="Is6vwYNjF5tMTBiMLOnlir" Comment="Color Resolution" Bounds="406,72,64,15" ShowValueBox="true" isIOBox="true" Value="R720p">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <Choice Kind="TypeFlag" Name="ColorResolution" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Pad Id="UeIhEBjpZr5PdKCgLrdTPs" Comment="FPS" Bounds="626,105,55,15" ShowValueBox="true" isIOBox="true" Value="FPS30">
+              <p:TypeAnnotation LastCategoryFullName="Microsoft.Azure.Kinect.Sensor" LastSymbolSource="Microsoft.Azure.Kinect.Sensor.dll">
+                <Choice Kind="TypeFlag" Name="FPS" />
+              </p:TypeAnnotation>
+            </Pad>
+            <Node Bounds="766,364,38,26" Id="U8eGmSkC5EAQFuXUnyCraI">
+              <p:NodeReference LastCategoryFullName="Graphics.Imaging.Image" LastSymbolSource="VL.Imaging.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="MutableInterfaceType" Name="Image" />
+                <Choice Kind="OperationCallFlag" Name="Info" />
+              </p:NodeReference>
+              <Pin Id="JfHgXICHhIxLerGXRzAJvW" Name="Input" Kind="StateInputPin" />
+              <Pin Id="RWBSNnh58bnMSXF5qqK30y" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="FQmOqJZSqA6Pq6CohJ7aU4" Name="Info" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="725,434,62,26" Id="HyK7kZ29XZDPU1eb5dd2QF">
+              <p:NodeReference LastCategoryFullName="Graphics.Imaging.ImageInfo" LastSymbolSource="VL.Imaging.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="RecordType" Name="ImageInfo" />
+                <Choice Kind="OperationCallFlag" Name="Width" />
+              </p:NodeReference>
+              <Pin Id="JONksjjpQjGP5cXWZc0CbT" Name="Input" Kind="StateInputPin" />
+              <Pin Id="OUUS2MVHJEMMFISyLYM1lt" Name="Width" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="816,435,62,26" Id="ODAed4LBC3BMOLYjPiQYRy">
+              <p:NodeReference LastCategoryFullName="Graphics.Imaging.ImageInfo" LastSymbolSource="VL.Imaging.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="RecordType" Name="ImageInfo" />
+                <Choice Kind="OperationCallFlag" Name="Height" />
+              </p:NodeReference>
+              <Pin Id="Es64Lr5ov9ZLf3itcj0wOW" Name="Input" Kind="StateInputPin" />
+              <Pin Id="CiZBwOs1NRYMj1ZT200sLr" Name="Height" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="775,479,46,19" Id="NHRDndRg2PjQQdzKWJa7dB">
+              <p:NodeReference LastCategoryFullName="2D.Vector2" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Vector2Type" Name="Vector2" />
+                <Choice Kind="OperationCallFlag" Name="Vector (Join)" />
+              </p:NodeReference>
+              <Pin Id="Sjre45801GEQKN5oQdEDMk" Name="X" Kind="InputPin" />
+              <Pin Id="Cv9yJOE1V5LPYHF86aFg6D" Name="Y" Kind="InputPin" />
+              <Pin Id="BB9y5cTwpVXMt8AnW12PWj" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <ControlPoint Id="CSPMinkmv1GMA2Ue8CA7Qh" Bounds="778,534" />
+            <Node Bounds="378,385,108,19" Id="IlR30emarRoM9DBW2vlbqq">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="ColorToDepthImage" />
+              </p:NodeReference>
+              <Pin Id="LslqYPlEUwCO6UAm059EUS" Name="Sensor" Kind="InputPin" />
+              <Pin Id="PyFVKOMIxwkNnyc53zqfhF" Name="Output" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="OJY0MLRAZE4MbIRxnnULw0" Bounds="382,464" />
+            <Node Bounds="193,340" Id="DTSomThyDCaO3bZSnLH1Uu">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="Category" Name="AzureKinect" />
+                <Choice Kind="ProcessAppFlag" Name="PointCloud" />
+              </p:NodeReference>
+              <Pin Id="Dyb3yo7eAjJMoxtWwwnziv" Name="Device" Kind="InputPin" />
+              <Pin Id="HULOJpfpUZfMu2KaS0X3bO" Name="Decimation" Kind="InputPin" />
+              <Pin Id="O95z1kLhecdOA5MNADIWan" Name="Minimum Z" Kind="InputPin" />
+              <Pin Id="ILSIRBtm00hL4dEHQFAc0N" Name="Maximum Z" Kind="InputPin" />
+              <Pin Id="Ahk2qWzlgYrPo92HqnzL32" Name="Output" Kind="OutputPin" />
+            </Node>
+            <Node Bounds="60,405,107,26" Id="OKuXmbZIBN0Lpunn0EgwjK">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.CoreLib.VVVV.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToBufferDescription" />
+                <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="QEBXzgZwTj3O0K6bFnZWBw" Name="Data" Kind="InputPin" />
+              <Pin Id="RsdPI3MBEYQLMNI2vjadW0" Name="Set" Kind="InputPin" />
+              <Pin Id="TrgvHvkx0ioQAevWOUBhCr" Name="Output" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="MHXGBWvmK9XPREElY5NaN9" Bounds="66,457" />
+            <Node Bounds="1049,293,140,19" Id="I7ippWepzgiMyCSKnGD846">
+              <p:NodeReference LastCategoryFullName="Devices.AzureKinect" LastSymbolSource="VL.Devices.AzureKinect.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="DepthRayTable" />
+                <PinReference Kind="InputPin" Name="Device" />
+                <CategoryReference Kind="Category" Name="AzureKinect" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="BOsX9sr81qyLcfDvbL3FUp" Name="Device" Kind="InputPin" />
+              <Pin Id="I6KkzfLVctPNLDEDcqNhij" Name="XY Table" Kind="OutputPin" />
+              <Pin Id="Q1v7yHIqn7ONmaKFqPsg0f" Name="Depth Camera Intrinsic Parameters" Kind="OutputPin" />
+              <Pin Id="EmrXekBE0lWQaxq0SiNmfD" Name="HasChanged" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="E3y0k5Fk9iLPLLN3R26lPj" Bounds="1054,409" />
+            <Node Bounds="1051,334,107,26" Id="GLCND0em21rLuqZF5ZYHWB">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.CoreLib.VVVV.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="ToBufferDescription" />
+                <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="PBUOU558p2CLKVAILyXtE2" Name="Data" Kind="InputPin" />
+              <Pin Id="HjGmeV0pyr4Lf8Lfb1NNDf" Name="Set" Kind="InputPin" />
+              <Pin Id="BPv0LI8ew1gMHFMRn5XNh4" Name="Output" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="UsXHQMnZMixMRqzkh72GXn" Bounds="1187,410" />
+            <ControlPoint Id="KAZZOq6ugkcOWIHSoj9N4Z" Bounds="427,125" />
+            <ControlPoint Id="FruzsmN6qQFMSf4CmQwM6a" Bounds="449,164" />
+            <Node Bounds="191,394,44,26" Id="OpBqpxC4yILQRWQT4rdH50">
+              <p:NodeReference LastCategoryFullName="Collections.Spread" LastSymbolSource="VL.Collections.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="OperationCallFlag" Name="Count" />
+                <CategoryReference Kind="RecordType" Name="Spread" NeedsToBeDirectParent="true" />
+              </p:NodeReference>
+              <Pin Id="EbjCgkPNQxaL20XXztkes7" Name="Input" Kind="StateInputPin" />
+              <Pin Id="Rpu52LxX73SOL7sszUe3p0" Name="Count" Kind="OutputPin" />
+            </Node>
+            <ControlPoint Id="LJ5N9QE3jSTLKWJ8CvFkhU" Bounds="191,452" />
+            <ControlPoint Id="KDXrrZNhQ2PMDGwUNSsQv5" Bounds="7,318" />
+            <ControlPoint Id="Jdy5p1UcLXPQNlCL0gZMIx" Bounds="1336,526" />
+            <Node Bounds="1333,466" Id="BQmkeSTuNIrP8dz3sToZFb">
+              <p:NodeReference LastCategoryFullName="Control" LastSymbolSource="CoreLibBasics.vl">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <Choice Kind="ProcessAppFlag" Name="MonoFlop" />
+              </p:NodeReference>
+              <Pin Id="OJJEEyFPulEQSdoc12MRUc" Name="Set" Kind="InputPin" />
+              <Pin Id="EvA1EwQgfyvMemlDfJTvGe" Name="Time" Kind="InputPin" />
+              <Pin Id="GPtX78T1TXnL6rYiPQI94A" Name="Retriggerable" Kind="InputPin" />
+              <Pin Id="KQaIPpRXRthLZgxXzPL1EE" Name="Reset" Kind="InputPin" />
+              <Pin Id="PNl8JZA51p0QL8QVxyLXf4" Name="Value" Kind="OutputPin" />
+              <Pin Id="CBprK2HlyUZMO1Mep42vwy" Name="Inverse Output" Kind="OutputPin" />
+            </Node>
+          </Canvas>
+          <ProcessDefinition Id="FHNLl8GWgcVOJzRkkPI83E">
+            <Fragment Id="MRFnVwHDf0WOO7H3jKbCxI" Patch="ESJZDDS0I02LAWDOx9RJVV" Enabled="true" />
+            <Fragment Id="PulIQZQ5YLtPp6C2yvbTNE" Patch="OkqGvJfa3PDOppp4PFQghD" Enabled="true" />
+          </ProcessDefinition>
+          <Link Id="N5GoAakHAnGMX9vK6c9fQC" Ids="NEB5RMChfrNMmwByqXXDPg,I7lOSjrOXOiNKLrh3hvx8O" />
+          <Link Id="HRrUJ5RlAmGMPmwL4h54TK" Ids="KrVnZKn4szVPR6qBjIaOuU,Dibzz50jh3qL2fhuIZ8rFg" IsHidden="true" />
+          <Link Id="OtzkrFdbx3dM7s8BQS1gn6" Ids="Itr4TMRwsLkLt6mseVE94K,DGUtQKzu7BZLhXaMnimNuE" />
+          <Link Id="K4jL46UfFXgQEYv7I5HLK4" Ids="KhFw1lUlEe8OJdgweOfAeX,Itr4TMRwsLkLt6mseVE94K" IsHidden="true" />
+          <Link Id="TsNLPP7acOxP3qca17nAHG" Ids="NEB5RMChfrNMmwByqXXDPg,LKLFSuOSdVoNbJIzHOHoXH" />
+          <Link Id="FDYNN3rId7zOSjxbWs1PBh" Ids="P5PQM3632ajPn3vbVCMBnu,VqbBx7CkZvbLfykQONyeP1" />
+          <Link Id="NZucVtuKbTKLuB68AP09cc" Ids="VqbBx7CkZvbLfykQONyeP1,TTSxvzhmYZaPgsbKXSnTnx" IsHidden="true" />
+          <Link Id="DIFWvdypIqKOAbJsiLkULu" Ids="Is6vwYNjF5tMTBiMLOnlir,AGR24cHmhEKQFGAhKdZuqB" />
+          <Link Id="GePJcStedjyLEnlzh0e7Qt" Ids="K2Unpt8IrMbQC1qkgCzNeT,KrVnZKn4szVPR6qBjIaOuU" />
+          <Link Id="TAuksGFsOgaPDBdjSt96yJ" Ids="K2Unpt8IrMbQC1qkgCzNeT,JfHgXICHhIxLerGXRzAJvW" />
+          <Link Id="DOP5z2uJPk5Mkhf8tQtdzr" Ids="FQmOqJZSqA6Pq6CohJ7aU4,JONksjjpQjGP5cXWZc0CbT" />
+          <Link Id="ULTVkc09sRpOHXsVkWTgRD" Ids="FQmOqJZSqA6Pq6CohJ7aU4,Es64Lr5ov9ZLf3itcj0wOW" />
+          <Link Id="Gge8HSXQu2SQTjrPzyWktO" Ids="OUUS2MVHJEMMFISyLYM1lt,Sjre45801GEQKN5oQdEDMk" />
+          <Link Id="B3fkzXDMSaEMCKJERPBdLf" Ids="CiZBwOs1NRYMj1ZT200sLr,Cv9yJOE1V5LPYHF86aFg6D" />
+          <Link Id="ULjphqeUO68L1FlF8S2lBv" Ids="BB9y5cTwpVXMt8AnW12PWj,CSPMinkmv1GMA2Ue8CA7Qh" />
+          <Link Id="Ca1e3DaPJruPZIa1g5X05x" Ids="CSPMinkmv1GMA2Ue8CA7Qh,IuHLsV00fJkLQcLes8NVvC" IsHidden="true" />
+          <Link Id="GtfTRy0OcW4N47JL2FT00s" Ids="NEB5RMChfrNMmwByqXXDPg,LslqYPlEUwCO6UAm059EUS" />
+          <Link Id="LMjMjyqUmuSPXhssFJO0qY" Ids="PyFVKOMIxwkNnyc53zqfhF,OJY0MLRAZE4MbIRxnnULw0" />
+          <Link Id="S6U6dOlkzcGOl0diyioIU9" Ids="OJY0MLRAZE4MbIRxnnULw0,JGiEnFgnn43PIbgtVxm8fl" IsHidden="true" />
+          <Link Id="JfefSsmXSgcPmKk00oMEN9" Ids="NEB5RMChfrNMmwByqXXDPg,Dyb3yo7eAjJMoxtWwwnziv" />
+          <Link Id="AUDS0UAxW1jOkMYi8l4yzm" Ids="Ahk2qWzlgYrPo92HqnzL32,QEBXzgZwTj3O0K6bFnZWBw" />
+          <Link Id="KJxKPW7qSjsOp54MOmNrcp" Ids="TrgvHvkx0ioQAevWOUBhCr,MHXGBWvmK9XPREElY5NaN9" />
+          <Link Id="AqCh3p61V5SOB0ambjqSp0" Ids="MHXGBWvmK9XPREElY5NaN9,QEIPQSuDEyVL1cXY9KLFR3" IsHidden="true" />
+          <Link Id="LVMDTf8qNuZLddx6K4dDwK" Ids="E3y0k5Fk9iLPLLN3R26lPj,R0ezdmFbyhEPx3CmmTohGM" IsHidden="true" />
+          <Link Id="BD2a1vtq3vkO3nU4GDpkxP" Ids="NEB5RMChfrNMmwByqXXDPg,BOsX9sr81qyLcfDvbL3FUp" />
+          <Link Id="KKYgrIiEdt0NgbrQYiOltj" Ids="I6KkzfLVctPNLDEDcqNhij,PBUOU558p2CLKVAILyXtE2" />
+          <Link Id="AoH3rJH3eIELwWIIGeEDJt" Ids="BPv0LI8ew1gMHFMRn5XNh4,E3y0k5Fk9iLPLLN3R26lPj" />
+          <Link Id="NzLjXxCLhDaNFryvBGLr1S" Ids="EmrXekBE0lWQaxq0SiNmfD,UsXHQMnZMixMRqzkh72GXn" />
+          <Link Id="AZgWmvNWopBPerCGdPxVtR" Ids="UsXHQMnZMixMRqzkh72GXn,RfhLHlTKCf3PHEANMG69bO" IsHidden="true" />
+          <Link Id="K5FTn4ye7H1LC4JQyGMIFo" Ids="EmrXekBE0lWQaxq0SiNmfD,HjGmeV0pyr4Lf8Lfb1NNDf" />
+          <Link Id="TE1FZB3VAccOqByhmocETL" Ids="KAZZOq6ugkcOWIHSoj9N4Z,GijOIAKPAEsP13nlZ2ww3N" />
+          <Link Id="FJlsvw4isOELyhFtEBUQOI" Ids="GxnPj7AARp3MQ6y8bspCcv,KAZZOq6ugkcOWIHSoj9N4Z" IsHidden="true" />
+          <Link Id="RJzb1WKBT7aNk13rE6W2pz" Ids="FruzsmN6qQFMSf4CmQwM6a,Vt7YUxbAc2yLJEmfnLjWJF" />
+          <Link Id="S6UPBWcJKsBLWV7dxUTF0V" Ids="TSx9JfyLSN2O4oZdd0at20,FruzsmN6qQFMSf4CmQwM6a" IsHidden="true" />
+          <Link Id="FtbIqHD3PpKLzYdK4n2Zh0" Ids="Ahk2qWzlgYrPo92HqnzL32,EbjCgkPNQxaL20XXztkes7" />
+          <Link Id="GmSgpfnHECrOwU9O1JYWg8" Ids="Rpu52LxX73SOL7sszUe3p0,LJ5N9QE3jSTLKWJ8CvFkhU" />
+          <Link Id="MUo8HP3LyKUNAmkkAqt8J9" Ids="LJ5N9QE3jSTLKWJ8CvFkhU,V06Ud1YtPNoMU3ukQaCXg3" IsHidden="true" />
+          <Link Id="JmwWr9ovdPRQSZOUiGMuP6" Ids="NEB5RMChfrNMmwByqXXDPg,KDXrrZNhQ2PMDGwUNSsQv5" />
+          <Link Id="KAgaXpJtwsUOXfKYPWZpKE" Ids="KDXrrZNhQ2PMDGwUNSsQv5,UgE9bgHaeguL8v8xBbS2Mp" IsHidden="true" />
+          <Link Id="EiQi7uyqDabNcW27mP4aa6" Ids="Jdy5p1UcLXPQNlCL0gZMIx,R4GHi5w35d6PbqVFQtEXIE" IsHidden="true" />
+          <Link Id="IaefWwM8ENyLQQQq8tdcu1" Ids="OEqm2crhlERPTn9x3o3b65,OJJEEyFPulEQSdoc12MRUc" />
+          <Link Id="NnCNoW687s3NjjHUqXVzXm" Ids="PNl8JZA51p0QL8QVxyLXf4,Jdy5p1UcLXPQNlCL0gZMIx" />
+        </Patch>
+      </Node>
+    </Canvas>
+    <!--
+
+    ************************ Application ************************
+
+-->
+    <Node Name="Application" Bounds="100,100" Id="Pu817ClDAhPOqvF24GR8Eh">
+      <p:NodeReference>
+        <Choice Kind="ContainerDefinition" Name="Process" />
+        <FullNameCategoryReference ID="Primitive" />
+      </p:NodeReference>
+      <Patch Id="QWETX3sX4xiOKVLwgnkLEg">
+        <Canvas Id="B92OWsimjwlMUoBUpcGzpn" BordersChecked="false" CanvasType="Group" />
+        <Patch Id="CeSpNUykYr4MEjdBKV8mIq" Name="Create" />
+        <Patch Id="AFWHnnKwDoSMYgwtrogLS8" Name="Update" />
+        <ProcessDefinition Id="PwhdyMmE08qOgbTPzwKgs4">
+          <Fragment Id="TXuCSFnlhbNQS6u09EEnvH" Patch="CeSpNUykYr4MEjdBKV8mIq" Enabled="true" />
+          <Fragment Id="DDptVlu9ffqNQJnDz5Q28U" Patch="AFWHnnKwDoSMYgwtrogLS8" Enabled="true" />
+        </ProcessDefinition>
+      </Patch>
+    </Node>
+  </Patch>
+  <NugetDependency Id="PtD33AjjGT2N153n4TJJrL" Location="VL.Devices.AzureKinect" Version="0.2.4-alpha" />
+  <NugetDependency Id="SUROnqIxdicPReG4PAIeej" Location="VL.Skia" Version="2020.1.4" />
+  <NugetDependency Id="EPcpTXn2JxgMdx8zpVQF7g" Location="VL.Skia3d" Version="1.0.36-alpha" />
+  <NugetDependency Id="BBzVMBiKiOrNfpBrMCdLut" Location="Microsoft.Azure.Kinect.Sensor" Version="1.4.0" />
+</Document>


### PR DESCRIPTION
This is a Drop-In replacement for Kinect or Kinect2 modules to enable [Kinect Azure](https://en.wikipedia.org/wiki/Azure_Kinect)

It is based on [VL.Devices.AzureKinect](https://github.com/vvvv/VL.Devices.AzureKinect), and requires this PR:
https://github.com/vvvv/VL.Devices.AzureKinect/pull/2

Texture generation is done performantly in dx11 texture shaders, which should be much faster than OpenCV approaches.